### PR TITLE
Made the "you@email.com" string translatable

### DIFF
--- a/invitations-for-slack/admin/settings.php
+++ b/invitations-for-slack/admin/settings.php
@@ -137,7 +137,7 @@ class SlackInviter_Admin_Settings {
 						<?php $title = __( 'Shortcodes', 'invitations-for-slack' ); ?>
 						<th scope="row"><?php echo esc_html( $title ); ?></th>
 						<td>
-							<p class="description"><?php esc_html_e( 'The following shortcodes are required to create the the Slack invitation forms. Use them on your invitation page(s).', 'invitations-for-slack' ); ?></p>
+							<p class="description"><?php esc_html_e( 'The following shortcodes are required to create the Slack invitation forms. Use them on your invitation page(s).', 'invitations-for-slack' ); ?></p>
 							<dl>
 								<dt><code>[invitations_for_slack]</code></dt>
 								<dd><?php esc_html_e( 'The primary code to allow users to sign up', 'invitations-for-slack' ); ?></dd>

--- a/invitations-for-slack/core/functions.php
+++ b/invitations-for-slack/core/functions.php
@@ -212,7 +212,7 @@ class SlackInviter_Core_Functions {
 			$content .= '             <div class="team-stats">' . sprintf( __( '<strong class="online">%s</strong> users online. <strong class="registered">%s</strong> registered.', 'invitations-for-slack' ), '[STATS_ONLINE]', '[STATS_TOTAL]' ) . '</div>';
 
 			if ( $data['allow_different_email'] ) {
-				$content .= '             <input type="text" placeholder="you@email.com" />';
+				$content .= '             <input type="text" placeholder="' . __( 'you@email.com', 'invitations-for-slack' ) . '" />';
 			} else {
 				$content .= '             <input type="hidden" value="[USER_EMAIL]" />';
 			}


### PR DESCRIPTION
Well... while translating the plugin into German I noticed I wasn't able to translate the placeholder email. Since it's the only string left, I'd like to translate it too 🙃 

Now I can. 