### PR TITLE
Fixes PHP warning on settings screen on activation

### DIFF
--- a/invitations-for-slack/admin/settings.php
+++ b/invitations-for-slack/admin/settings.php
@@ -110,7 +110,7 @@ class SlackInviter_Admin_Settings {
 
 					<!-- WEB API SETTINGS -->
 					<?php
-					$channels = SlackInviter::get_setting( 'channels', '' );
+					$channels = SlackInviter::get_setting( 'channels', array() );
 					$channels = implode( "\n", $channels );
 					?>
 					<tr>


### PR DESCRIPTION
When visiting the settings screen after activation, a PHP warning is thrown because no channels are saved yet and a string cannot be imploded:

```
Warning: implode(): Invalid arguments passed in /var/www/baapwp.me/htdocs/wp-content/plugins/invitations-for-slack/invitations-for-slack/admin/settings.php on line 114
```